### PR TITLE
Remove the logger for PayPal Ruby SDK

### DIFF
--- a/config/initializers/paypal.rb
+++ b/config/initializers/paypal.rb
@@ -1,2 +1,1 @@
 PayPal::SDK.load("config/paypal.yml", Rails.env)
-PayPal::SDK.logger = Rails.logger


### PR DESCRIPTION
Paypal provides an way to log the paypal details, but we decided not to use it, so lets remove the PayPal SDK logger configuration from it's configuration file.