### PR TITLE
Sets PayPal SDK logger to :unknown

### DIFF
--- a/config/initializers/paypal.rb
+++ b/config/initializers/paypal.rb
@@ -1,1 +1,2 @@
 PayPal::SDK.load("config/paypal.yml", Rails.env)
+PayPal::SDK.logger.level = Logger::UNKNOWN


### PR DESCRIPTION
We are not using PayPal logger for any of our development related tasks, so let's sets the logger to unknown so it doesn't make any extra noises both in development and test environment.