### PR TITLE
Open certificate in content edit mode

### DIFF
--- a/app/views/admin/certificates/_index.html.erb
+++ b/app/views/admin/certificates/_index.html.erb
@@ -15,6 +15,10 @@
         <%= link_to(
           "edit", edit_admin_certificate_path(certificate)
         ) %>
+
+      <%= link_to(
+        "content", certificate_content_path(certificate), target: "_blank"
+      ) %>
     </td>
     </tr>
   <% end %>

--- a/spec/features/management_admin_edit_certificate_spec.rb
+++ b/spec/features/management_admin_edit_certificate_spec.rb
@@ -25,4 +25,14 @@ feature "Certificate editing" do
     expect(page).to have_content(cert_attr.name)
     expect(page).to have_content(content.certificate.status)
   end
+
+  scenario "management admin open certificate in edit mode" do
+    content = create(:content, certificate: create(:certificate))
+    visit root_path(as: create(:admin, company: create(:owner_company)))
+    visit admin_certificates_path
+    click_on "content"
+
+    expect(current_path).to eq certificate_content_path(content.certificate)
+    expect(page).to have_content("Submit for approval")
+  end
 end


### PR DESCRIPTION
In some rare case, management admin might need to fix/change certificate content based on business admin request, so lets add the functionality to allow management admin to open cert in edit mode so necessary changes can be made.