### PR TITLE
Fix RSpec deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.4.0"
+  gem "rspec-rails", "~> 3.4.2"
   gem "wkhtmltopdf-binary"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
     render_anywhere (0.0.12)
       rails (>= 3.0.7)
     rmagick (2.15.4)
-    rspec-core (3.4.3)
+    rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -462,7 +462,7 @@ DEPENDENCIES
   refills
   render_anywhere
   rmagick
-  rspec-rails (~> 3.4.0)
+  rspec-rails (~> 3.4.2)
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form
@@ -477,5 +477,8 @@ DEPENDENCIES
   wkhtmltopdf-binary
   wkhtmltopdf-heroku
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.2


### PR DESCRIPTION
After the last rails update there was some pending deprecation warnings, those does not effect the application directly but make extra noices in the test suite.