### PR TITLE
Change certificate content creation process

### DIFF
--- a/app/assets/javascripts/certificate_editor.js
+++ b/app/assets/javascripts/certificate_editor.js
@@ -1,3 +1,5 @@
+//= require jquery
+//= require jquery_ujs
 //= require ContentTools/content-tools
 //= require ContentTools/cloudinary-image-uploader
 //= require editor.init

--- a/app/assets/stylesheets/certificate_editor.scss
+++ b/app/assets/stylesheets/certificate_editor.scss
@@ -1,9 +1,19 @@
 @import "ContentTools/content-tools";
+$danger-color: #a94442;
+$content-width: 800px;
 
 body{
   background: #eee;
   font-family: Calibri, Candara, Segoe, 'Segoe UI', Optima, Arial, sans-serif;
   text-align: justify;
+
+  .flashes {
+    color: $danger-color;
+    margin: 0 auto;
+    padding: 10px 0 0;
+    text-align: center;
+    width: $content-width;
+  }
 
   .certificate_wrapper{
     width: 595px;

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -44,6 +44,10 @@ class Certificate < ActiveRecord::Base
     contents.last
   end
 
+  def publishable?
+    !required_content_field_missing?
+  end
+
   def send_certificate(user:)
     kit = kits.generate(business: company)
     kit.user = user
@@ -60,5 +64,9 @@ class Certificate < ActiveRecord::Base
   def company_scope_kits(user_company)
     user_company ||= company
     kits.where(company: user_company)
+  end
+
+  def required_content_field_missing?
+    content.nil? || title.nil? || sub_title.nil?
   end
 end

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "flashes" %>
+
 <div
   id="certificate_wrapper"
   class="certificate_pdf certificate_wrapper"
@@ -41,7 +43,7 @@
   <p>
   <%= link_to(
     "Submit for approval",
-    certificate_content_path(@certificate, ready: true)
+    certificate_content_path(@certificate), method: :patch
   ) %>
 </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,8 +54,9 @@ en:
       errors: "Please fix the errors before updating the certificate."
 
     content:
-      create:
-        ready: "Your certificate has been submitted for approval"
+      ready: "Your certificate has been submitted for approval"
+      missing:
+        "Please use the visual tool (blue pencil on the top left side of the screen) to edit and save your certificate content before submitting for approval."
 
       title:
         "<h2>Time to edit your certificate, your header goes here!</h2>"

--- a/spec/features/admin_creates_new_certificate_spec.rb
+++ b/spec/features/admin_creates_new_certificate_spec.rb
@@ -2,11 +2,33 @@ require "rails_helper"
 
 feature "Certificate creation" do
   scenario "admin creates certificate" do
+    visit_new_certificate_page
+    submit_new_cerficate_form
+
+    certificate = Certificate.last
+    create(:content, certificate: certificate)
+    click_on "Submit for approval"
+
+    expect(certificate.banner).not_to be_nil
+    expect(current_path).to eq(certificates_path)
+    expect(page).to have_content("Your certificate has been submitted")
+  end
+
+  scenario "admin tries to create invalid certificate" do
+    visit_new_certificate_page
+    submit_new_cerficate_form
+    click_on "Submit for approval"
+
+    expect(page).to have_content("Please use the visual tool (blue pencil")
+  end
+
+  def visit_new_certificate_page
     visit root_path(as: create(:user, admin: true))
     visit marketer_path
-
     click_on "New Certificate"
+  end
 
+  def submit_new_cerficate_form
     attach_file(
       "Banner",
       File.join(Rails.root, "/spec/factories/files/banner.png")
@@ -18,10 +40,5 @@ feature "Certificate creation" do
     fill_in "certificate_expires_in", with: 12
     fill_in "certificate_duration", with: 7
     click_on "Create"
-
-    click_on "Submit for approval"
-
-    expect(page).to have_content("Submit for approval")
-    expect(Certificate.last.banner).not_to be_nil
   end
 end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe Certificate, type: :model do
       expect(user.kits.last.status).to eq("Pending")
     end
   end
+
+  describe "#publishable?" do
+    it "returns true if there is valid content" do
+      certificate = create(:certificate)
+      create(:content, certificate: certificate)
+
+      expect(certificate.publishable?).to eq(true)
+    end
+
+    it "returns false where there is not existing content" do
+      certificate = create(:certificate)
+      expect(certificate.publishable?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Certificate content creation page is expecting user to edit the content using visual tools and once they are ready then submit that for approval. But the problem is most of user tries to submit it without adding necessary content.

So let's change this process, now if user tries to submit a certificate without required content then it would not allow it unless they use the visual tool to add/edit their content.